### PR TITLE
Update names - woodcutting group bonus & leprechaun's luck

### DIFF
--- a/scripts/[proc,buff_bar_get_value].cs2
+++ b/scripts/[proc,buff_bar_get_value].cs2
@@ -444,12 +444,12 @@ switch_struct ($struct0) {
 		if (%varcint1193 > 0) {
 			return(%varbit9853);
 		}
-	case struct_4693 :
+	case buff_woodcutting_group_bonus_4693 :
 		if (%var4007 = 96 & %varbit15348 > 0) {
 			return(%varbit15348);
 		}
 		return(0);
-	case struct_4694 :
+	case buff_leprechauns_luck_4694 :
 		if (%varbit15350 = 0 & ~axe_checker = null) {
 			return(0);
 		}

--- a/scripts/[proc,script5924].cs2
+++ b/scripts/[proc,script5924].cs2
@@ -197,9 +197,9 @@ switch_struct ($struct0) {
 		cc_setonvartransmit("buff_bar_transmit_value($struct0){var3150, var2903}");
 	case buff_shooting_star_discovery_bonus_4695 :
 		cc_setonvartransmit("buff_bar_transmit_value($struct0){var2924}");
-	case struct_4693 :
+	case buff_woodcutting_group_bonus_4693 :
 		cc_setonvartransmit("buff_bar_transmit_value($struct0){var4007, var4008}");
-	case struct_4694 :
+	case buff_leprechauns_luck_4694 :
 		cc_setonvartransmit("buff_bar_transmit_value($struct0){var4004, var3190}");
 		cc_setoninvtransmit("buff_bar_transmit_value($struct0){inv, worn}");
 	case buff_scurrius_food_pile_cooldown_776 :


### PR DESCRIPTION
Not sure if you accept PRs, but in case you do...

Struct 4693 is the woodcutting group bonus code (please refer to script 5846 for confirmation), which I also use in <https://github.com/runelite/runelite/pull/17219>

I'm not 100% sure what varbit15350 does, but struct 4694 is the leprechaun's luck (see script 5846  again for confirmation). I'm unable to confirm this ingame though, since the leprechaun charms got removed.